### PR TITLE
Iterations.jl replaced by IterTools.jl

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,5 @@
 julia 0.5
 QuantEcon
 Compat 0.17
-Iterators
+IterTools
 Combinatorics

--- a/src/BasisMatrices.jl
+++ b/src/BasisMatrices.jl
@@ -26,7 +26,7 @@ using QuantEcon: gridmake, gridmake!, ckron, fix, fix!
 
 using Compat
 using Combinatorics: with_replacement_combinations
-using Iterators: product
+using IterTools: product
 
 # types
 export BasisFamily, Cheb, Lin, Spline, Basis, Smolyak,


### PR DESCRIPTION
terators.jl has been deprecated in favour of IterTools.jl.

See https://github.com/JuliaCollections/Iterators.jl/issues/104 for more information.