### PR TITLE
Avoid bounds violation with 0-degree Cheb. polynomial.

### DIFF
--- a/src/cheb.jl
+++ b/src/cheb.jl
@@ -172,6 +172,11 @@ function evalbasex!(out::AbstractMatrix, z::AbstractVector{T},
     if size(z) != size(x)
         throw(DimensionMismatch("z must be same size as x"))
     end
+    
+    if p.n == 1
+        out .= 1.0
+        return out
+    end
 
     # Note: for julia 0.6+ we can do z .= _unscale.(p, x)
     z .= _unscale.([p], x)

--- a/src/smol_util.jl
+++ b/src/smol_util.jl
@@ -77,6 +77,11 @@ function cheby2n!(out::AbstractArray{T}, x::AbstractArray{T,N},
     if size(out) != tuple(size(x)..., n+1)
         error("out must have dimensions $(tuple(size(x)..., n+1))")
     end
+    
+    if n == 0
+        out .= one(T)
+        return out
+    end
 
     R = CartesianRange(size(x))
     # fill first element with ones


### PR DESCRIPTION
Fixes bounds violation when evaluating 0-th degree Chebyshev polynomial by treating the case separately. Should fix #47.