### PR TITLE
Use Iterators.product instead of IterTools.product

### DIFF
--- a/src/BasisMatrices.jl
+++ b/src/BasisMatrices.jl
@@ -26,7 +26,7 @@ using QuantEcon: gridmake, gridmake!, ckron, fix, fix!
 
 using Compat
 using Combinatorics: with_replacement_combinations
-using IterTools: product
+using Base.Iterators: product
 
 # types
 export BasisFamily, Cheb, Lin, Spline, Basis, Smolyak,


### PR DESCRIPTION
In https://github.com/JuliaCollections/IterTools.jl/pull/35 we're considering deprecating `IterTools.product` in favour of `Iterators.product`. This PR implements this change for the use of `product` in BasisMatrices. Note that the order of the output has changed, but this doesn't appear to be an issue.